### PR TITLE
attribute traces renamed to data

### DIFF
--- a/seismicio/Models/SuDataModel.py
+++ b/seismicio/Models/SuDataModel.py
@@ -115,7 +115,7 @@ class SuFile:
           headers: Trace headers for this instance.
           gather_keyword: Header keyword that comprises the gathers.
         """
-        self.traces = data
+        self.data = data
         self.headers = headers
         self.num_traces = data.shape[1]
         self.gather_keyword = gather_keyword


### PR DESCRIPTION
A trace consists of both data and headers.
The name `traces` is misleading because this attribute actually only has the data from the traces, not both the data and headers. So it was renamed to `data`.